### PR TITLE
Adjust modules build for compatibility with dbt-cloud

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,12 +61,13 @@ jobs:
         run: docker save -o docker-cache.tar dbt-runner
 
 
-      - name: Run linters
-        run: inv lint
       - name: Initialize test database
         run: |
           PGPASSWORD=${POSTGRES_PASSWORD} createdb -h ${POSTGRES_HOST} -U ${POSTGRES_USER} ${POSTGRES_DBNAME}_dtspec
           inv init-test-db --ci
+
+      - name: Run linters
+        run: inv lint --ci
 
       - name: Run dtpsec test
         run: inv dtspec-test-dbt --ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV LANG C.UTF-8
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /dbt-runner
 ENV DBT_PROFILES_DIR /dbt-runner/dbt
+ENV DBT_MODULES_DIR /dbt_modules
 WORKDIR /dbt-runner
 
 # Conveniences

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -18,7 +18,7 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
-modules-path: "/dbt_modules"
+modules-path: "{{ env_var('DBT_MODULES_DIR', 'dbt_modules') }}"
 
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`

--- a/dbt/models/marts/core/dim_dates.sql
+++ b/dbt/models/marts/core/dim_dates.sql
@@ -1,0 +1,15 @@
+WITH spine AS (
+{{ dbt_utils.date_spine(
+      datepart="day",
+      start_date="to_date('2020-01-01', 'yyyy-mm-dd')",
+      end_date="to_date('2021-01-01', 'yyyy-mm-dd')"
+     )
+  }}
+)
+
+SELECT
+    date_day::DATE AS date_day,
+    date_part('MONTH', date_day) AS date_month,
+    date_part('YEAR', date_day) AS date_year
+FROM
+    spine

--- a/tasks.py
+++ b/tasks.py
@@ -137,8 +137,12 @@ def dbt_shell(ctx, docker_args=''):
     ))
 
 @task
-def lint(ctx, docker_args=''):
+def lint(ctx, docker_args='', ci=False):
     'Runs all linters'
+
+    if ci:
+        docker_args += '--network=host'
+
     ctx.run(docker_run_dbt_cmd(
         '"sqlfluff lint models"',
         interactive=False,


### PR DESCRIPTION
Use /dbt_modules for local container dev.  Use dbt_modules for dbt-cloud.
Include a simple dim_date model to ensure that dbt_utils is used.