### PR TITLE
WIP: Compose approach

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ COPY dbt/packages.yml /build_dbt_deps/packages.yml
 RUN cd /build_dbt_deps \
     && dbt deps
 
-ENTRYPOINT ["/bin/bash", "-c"]
+# ENTRYPOINT ["/bin/bash", "-c"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.7"
+
+services:
+
+  dbt-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - POSTGRES_HOST
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DBNAME
+    depends_on:
+      - postgres
+    tty: true
+    volumes:
+      - ".:/dbt-runner"
+    networks:
+      - default
+
+  postgres:
+    image: postgres:14.3-alpine
+    environment:
+      - POSTGRES_PASSWORD=password
+    ports:
+      - 5432
+    command: [
+      "-c",
+      "fsync=off",
+      "-c",
+      "synchronous_commit=off",
+      "-c",
+      "full_page_writes=off"
+    ]
+    tmpfs: /var/lib/postgresql/data:rw
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - "./postgres_init/mocked_db.sql:/docker-entrypoint-initdb.d/init.sql"
+    networks:
+      - default
+
+networks:
+  default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
       - POSTGRES_DBNAME
+    ports:
+      - "8000:8000"
     depends_on:
       - postgres
     tty: true
@@ -18,13 +20,14 @@ services:
       - ".:/dbt-runner"
     networks:
       - default
+    platform: linux/amd64
 
   postgres:
     image: postgres:14.3-alpine
     environment:
       - POSTGRES_PASSWORD=password
     ports:
-      - 5432
+      - "54321:5432"
     command: [
       "-c",
       "fsync=off",
@@ -43,6 +46,7 @@ services:
       - "./postgres_init/mocked_db.sql:/docker-entrypoint-initdb.d/init.sql"
     networks:
       - default
+    platform: linux/amd64
 
 networks:
   default:


### PR DESCRIPTION
This is a slight variation on the original skeleton, which uses docker compose to provision a Postgres container that can work as a target warehouse.

NOTE: if the `POSTGRES_HOST` is set to `host.docker.internal` then this setup would simply ignore the postgres container and use a server that the host is connected to.